### PR TITLE
add dependency to fail

### DIFF
--- a/.github/workflows/dependency_review.yml
+++ b/.github/workflows/dependency_review.yml
@@ -1,0 +1,16 @@
+name: 'Dependency Review'
+on: [pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout Repository'
+        uses: actions/checkout@v4
+      - name: 'Dependency Review'
+        uses: actions/dependency-review-action@v4
+        with:
+          config-file: 'amazon-ospo/dependency-review-config/default/dependency-review-config.yml@main'

--- a/input-stream/build.gradle.kts
+++ b/input-stream/build.gradle.kts
@@ -74,6 +74,7 @@ dependencies {
     implementation(libs.parquet.format)
     implementation(libs.slf4j.api)
     implementation(libs.caffeine)
+    implementation("software.aws.rds:aws-mysql-jdbc:1.1.15")
 
     jmhImplementation(libs.s3)
     jmhImplementation(libs.s3.transfer.manager)


### PR DESCRIPTION
This dependency check should fail as Gplv2 license is not allow-listed.
---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).